### PR TITLE
fix: updated phonenumber dataType schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,7 +16,7 @@ model User {
     last_name            String   @map(name: "last_name")
     profile_picture      String?  @map(name: "profile_picture")
     email                String
-    phonenumber          Int
+    phonenumber          String
     password_hash        String   @map(name: "password_hash")
     isAdmin              Boolean  @default(false) @map(name: "isAdmin")
     lunch_credit_balance String?  @map(name: "lunch_credit_balance")

--- a/src/helper/validate.js
+++ b/src/helper/validate.js
@@ -5,7 +5,7 @@ const UserSignupSchema = Joi.object({
   password: Joi.string().min(6).required(),
   first_name: Joi.string().required(),
   last_name: Joi.string().required(),
-  phonenumber: Joi.number().required(),
+  phonenumber: Joi.string().required(),
 });
 
 module.exports = {


### PR DESCRIPTION
Feat #26 

updated `phonenumber` data-type to String since JS doesn't support number starting with 0 as a prefix.